### PR TITLE
Add no response bot to CLI repo

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,9 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+daysUntilClose: 7
+responseRequiredLabel: 'more information required'
+closeComment: >
+  This issue has been automatically closed because there has been no response
+  to our request for more information from the original author. Currently, there
+  is not enough information provided for us to take action. Please reply and 
+  reopen this issue if you need additional assistance.


### PR DESCRIPTION
Bot that automatically closes issues labeled "more information required" after 7 days. 