### PR TITLE
Link to IdeaExchange for feature requests on another team

### DIFF
--- a/.github/workflows/new-label.yml
+++ b/.github/workflows/new-label.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, salesforce.com, inc.
+# Copyright (c) 2021, salesforce.com, inc.
 # All rights reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -12,49 +12,69 @@ on: # any labels added to an issue
 
 jobs:
   owned-by-other-team:
+    if: ${{ github.event.label.name == 'owned by another team' && !contains(github.event.issue.labels.*.name, 'feature') }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.0.0 
+    - uses: actions/checkout@v2.0.0
     - name: issue comment
       id: issue_comment
       uses: ./
-      with: 
+      with:
         repo-token: ${{ secrets.GITHUB_TOKEN}}
         label: 'owned by another team'
         message: >
           We have determined that the issue you reported exists in code owned by another team that uses only the official support channels.
-          To ensure that your issue is addressed, open an official Salesforce customer support ticket with a link to this issue.
+          To ensure that your issue is addressed, open an official [Salesforce customer support](https://help.salesforce.com/s/) ticket with a link to this issue.
           We encourage anyone experiencing this issue to do the same to increase the priority. We will keep this issue open for the community to collaborate on.
 
     - name: log action output
-      run: echo ${{steps.run_action.outputs.message}}     
+      run: echo ${{steps.run_action.outputs.message}}
   new-issue:
+    if: ${{ github.event.label.name == 'investigating' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.0.0 
+    - uses: actions/checkout@v2.0.0
     - name: issue comment
       id: issue_comment
       uses: ./
-      with: 
+      with:
         repo-token: ${{ secrets.GITHUB_TOKEN}}
         label: 'investigating'
         message: >
-          Thank you for filing this issue.  We appreciate your feedback and will review the issue as soon as possible. 
-          Remember, however, that GitHub isn't a mechanism for receiving support under any agreement or SLA. 
+          Thank you for filing this issue.  We appreciate your feedback and will review the issue as soon as possible.
+          Remember, however, that GitHub isn't a mechanism for receiving support under any agreement or SLA.
           If you require immediate assistance, contact Salesforce Customer Support.
     - name: log action output
-      run: echo ${{steps.run_action.outputs.message}}  
+      run: echo ${{steps.run_action.outputs.message}}
   new-feature:
+    if: ${{ github.event.label.name == 'feature' && !contains(github.event.issue.labels.*.name, 'owned by another team') }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.0.0 
+    - uses: actions/checkout@v2.0.0
     - name: issue comment
       id: issue_comment
       uses: ./
-      with: 
+      with:
         repo-token: ${{ secrets.GITHUB_TOKEN}}
         label: 'feature'
         message: >
           Thank you for filing this feature request. We appreciate your feedback and will review the feature at our next grooming or sprint planning session. We prioritize feature requests with more upvotes and comments.
     - name: log action output
-      run: echo ${{steps.run_action.outputs.message}}  
+      run: echo ${{steps.run_action.outputs.message}}
+  new-feature-on-another-team:
+    if: >-
+      (github.event.label.name == 'feature' || github.event.label.name == 'owned by another team')
+      &&
+      (contains(github.event.issue.labels.*.name, 'feature') && contains(github.event.issue.labels.*.name, 'owned by another team'))
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.0.0
+    - name: issue comment
+      id: issue_comment
+      uses: ./
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN}}
+        message: >
+          Thank you for filing this feature request. However, we have determined that the functionality you've requested would need to be completed by another team. Please submit your request to the [Salesforce IdeaExchange](https://trailblazer.salesforce.com/ideaSearch). Once submitted, please post a link to it in this issue so that other can upvote your idea.
+    - name: log action output
+      run: echo ${{steps.run_action.outputs.message}}

--- a/.github/workflows/new-label.yml
+++ b/.github/workflows/new-label.yml
@@ -75,6 +75,6 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN}}
         message: >
-          Thank you for filing this feature request. However, we have determined that the functionality you've requested would need to be completed by another team. Please submit your request to the [Salesforce IdeaExchange](https://trailblazer.salesforce.com/ideaSearch). Once submitted, please post a link to it in this issue so that other can upvote your idea.
+          Thank you for filing this feature request. However, we've determined that the functionality you've requested must be completed by another team. Please submit your request to the [Salesforce IdeaExchange](https://trailblazer.salesforce.com/ideaSearch). Then post a link to the request in this issue so that others can upvote your idea.
     - name: log action output
       run: echo ${{steps.run_action.outputs.message}}


### PR DESCRIPTION
[@W-8942519](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-8942519)

### Description
Directs users to the IdeaExchange when a `feature` being requested would be `owned by another team`. When both of these labels are present, a new message is displayed

### Additional changes:
* Added `if` statements to all steps so that they are skipped if not necessary. Should speed up the Actions slightly. 
* Added a link to Salesforce customer support in `owned by another team`


### Testing steps:
* Review logic added
* Review the new `message` added for `new-feature-on-another-team` 
* Confirm the added urls are correct
* Review changes in action on [iowillhoit/github-acitons](https://github.com/iowillhoit/github-actions)
    * [feature first, then owned by another team](https://github.com/iowillhoit/github-actions/issues/13)
        * [Action 1](https://github.com/iowillhoit/github-actions/actions/runs/1121479025)
        * [Action 2](https://github.com/iowillhoit/github-actions/actions/runs/1121480944)
    * [owned by another team first, then feature](https://github.com/iowillhoit/github-actions/issues/14)
        * [Action 1](https://github.com/iowillhoit/github-actions/actions/runs/1121484259)
        * [Action 2](https://github.com/iowillhoit/github-actions/actions/runs/1121486007) 
    * [investigation still works](https://github.com/iowillhoit/github-actions/issues/12)
        * [Action 1](https://github.com/iowillhoit/github-actions/actions/runs/1121459267)
    * [just a bug](https://github.com/iowillhoit/github-actions/issues/11) 
        * [No Actions ran on other labels](https://github.com/iowillhoit/github-actions/actions/runs/1121413936)


