### PR TITLE
Update docs for `sf` issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,8 +34,11 @@ _Describe what actually happened_.
 
 ### System Information
 
-Run `sfdx version --verbose --json` and paste the output here.
-
+- If you are using `sfdx`
+	- Run `sfdx version --verbose --json`
+- If you are using `sf`
+	- Run `sf version` **AND** `sf plugins --core`
+- Paste the output here
 ### Additional information
 
 _Feel free to attach a screenshot_.

--- a/README.md
+++ b/README.md
@@ -4,15 +4,13 @@ This is an issue-only repository for Salesforce CLI. We monitor this repository 
 
 If you have a feature or enhancement request for Salesforce CLI that is not related to our open-source repositories (see list below), please submit an issue here. 
 
-If you have encountered a bug in Salesforce CLI, please first go to the [Salesforce DX](https://success.salesforce.com/issues_index?tag=Salesforce%20DX) section in Known Issues to determine if there is already a documented workaround. If you don’t see your bug listed, please open an issue on this repository. 
+If you have encountered a bug in with the `sfdx` or `sf` CLI, please first go to the [Salesforce DX](https://success.salesforce.com/issues_index?tag=Salesforce%20DX) section in Known Issues to determine if there is already a documented workaround. If you don’t see your bug listed, please open an issue on this repository.
 
 NOTICE: GitHub is not a mechanism for receiving support under any agreement or SLA. If you require immediate assistance, please use official support channels.
 
 # A note on CLI Unification
 
 We recently introduced a new executable `sf` to Salesforce CLI. This is the realization of our strategy to unify our developer tooling across all Salesforce clouds and brands. See [Get Started with CLI Unification](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_sf_intro.htm) for more information.
-
-Submit `sf` bugs and feature requests directly to [the `sf` repo](https://github.com/salesforcecli/cli/issues). Continue to submit `sfdx` bugs and feature requests to [this repo](https://github.com/forcedotcom/cli/issues). Separating the issues related to the two executables allows the CLI team to keep them organized. 
 
 The release notes for both executables (`sf` and `sfdx`) are maintained in [this repo](https://github.com/forcedotcom/cli/tree/main/releasenotes). 
 


### PR DESCRIPTION
The GUS ticket linked updated the `salesforce/cli` repo to point to this repo for Issue. The PR updates docs to reflect that change. 

[@W-10004410@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-10004410)