### PR TITLE
RN April 29

### DIFF
--- a/releasenotes/sf/README.md
+++ b/releasenotes/sf/README.md
@@ -12,6 +12,53 @@ Run `sfdx update stable-rc` to update to the release candidate for both `sf` and
 
 ## 1.26.0 (May 5, 2022) [stable-rc]
 
+* NEW: Create and manage scratch orgs and sandboxes with these new beta commands:
+
+    ```
+    env create scratch
+    env resume scratch
+    env delete scratch
+    env create sandbox
+    env resume sandbox
+    env delete sandbox
+    ```
+
+    The two `create` commands display running information about the background processes, such as sending requests to the Dev Hub or production org, deploying settings, and so on. Use the `resume` command if the original `create` command times out, or you specified the `--async` flag to run the create asynchronously. Use the `delete` commands to, yep, you guessed it, delete a scratch org or sandbox!
+
+    Let’s run through a few scratch org examples to see the new commands in action.
+
+    Create a scratch org from a definition file, set it as your default environment, give it an alias, and use the Dev Hub with alias `DevHub`:
+
+    ```
+    sf env create scratch --definition-file config/project-scratch-def.json --set-default --alias myscratch --target-dev-hub DevHub
+    ```
+
+    Create a Developer Edition scratch org using your default Dev Hub and give it an alias:
+
+    ```
+    sf env create scratch --edition=developer --alias anotherscratch
+    ```
+
+    Create a scratch org asynchronously. The command returns control to you right away and displays a job ID:
+
+    ```
+    sf env create scratch --edition=developer --alias happyscratch --async
+    ```
+
+    Resume the scratch org creation by passing the job ID to the `resume` command:
+
+    ```
+    sf env resume scratch --job-id 2SR3u0000008fBDGXD
+    ```
+
+    Delete the scratch org when you’re done with it:
+
+    ```
+    sf env delete scratch --target-org happyscratch
+    ```
+
+    The `sandbox` commands work much the same, except they have a few additional flags specific to sandboxes, such as `--license-type` and `--name`. See the `--help` for all the flags.
+
 ## 1.25.2 (April 28, 2022) [stable]
  
 * CHANGE: We no longer support v12 of Node.js because of its fast approaching end-of-life ([April 30, 2022](https://nodejs.org/en/about/releases/)). We bundle Node.js in each operating system-specific Salesforce CLI installer. We include the Active LTS version of Node.js and update it in tandem with the Node.js release schedule. If you prefer to install Salesforce CLI using `npm`, we recommend you also use the Active LTS version of Node.js.

--- a/releasenotes/sf/README.md
+++ b/releasenotes/sf/README.md
@@ -10,7 +10,9 @@ Run `sfdx update stable-rc` to update to the release candidate for both `sf` and
 
 [Click here for the release notes for the `sfdx` executable.](../sfdx/README.md)
 
-## 1.25.0 (April 28, 2022) [stable-rc]
+## 1.26.0 (May 5, 2022) [stable-rc]
+
+## 1.25.2 (April 28, 2022) [stable]
  
 * CHANGE: We no longer support v12 of Node.js because of its fast approaching end-of-life ([April 30, 2022](https://nodejs.org/en/about/releases/)). We bundle Node.js in each operating system-specific Salesforce CLI installer. We include the Active LTS version of Node.js and update it in tandem with the Node.js release schedule. If you prefer to install Salesforce CLI using `npm`, we recommend you also use the Active LTS version of Node.js.
 

--- a/releasenotes/sfdx/README.md
+++ b/releasenotes/sfdx/README.md
@@ -25,6 +25,8 @@ These changes are in the Salesforce CLI release candidate. We plan to include th
 * FIX: `force:source:push` will correctly push LWC subfolders such as `force-app/lwc/foo/lwc/myLWC/**`. Thank you @yippie for [reporting](https://github.com/forcedotcom/cli/issues/1477) :bow:.
 * FIX: Deploys that time out now [include the deploy ID](https://github.com/forcedotcom/source-deploy-retrieve/pull/614), making various automations possible that otherwise required workarounds.
 
+* CHANGE: `force:org:list --clean` doesn't delete non-scratch orgs.  That's been confusing, so we updated the help to be clearer, which will also show up in the command docs.  Props to @jclark-dot-org for the [feedback](https://github.com/salesforcecli/plugin-org/pull/318)  
+
 ## 7.148.3 (April 29, 2022) [stable]
 
 > Note: we normally release on Thursdays, so you'd expect this to say April 28.  But since that's also day 2 of TDX, so we'll do the normal release stuff on Friday this week.

--- a/releasenotes/sfdx/README.md
+++ b/releasenotes/sfdx/README.md
@@ -18,7 +18,8 @@ Want to check out the new `sf` executable of Salesforce CLI? [Click here for the
 
 These changes are in the Salesforce CLI release candidate. We plan to include these changes in next week's official release. This list isn't final and is subject to change.
 
-* FIX: `force:source:pull` now respects `.forceignore` entries in the format `**.filename.ext`. Thank you @ImJohnMDaniel for [reporting this](https://github.com/forcedotcom/cli/issues/1471) with an excellent repro!
+* FIX: `force:source:pull` respects `.forceignore` entries in the format `**.filename.ext`. Thank you @ImJohnMDaniel for [reporting this](https://github.com/forcedotcom/cli/issues/1471) with an excellent repro!
+* FIX: `force:source:push` will correctly push LWC subfolders such as `force-app/lwc/foo/lwc/myLWC/**`. Thank you @yippie for [reporting](https://github.com/forcedotcom/cli/issues/1477) :bow:.
 
 ## 7.148.3 (April 29, 2022) [stable]
 

--- a/releasenotes/sfdx/README.md
+++ b/releasenotes/sfdx/README.md
@@ -20,6 +20,7 @@ These changes are in the Salesforce CLI release candidate. We plan to include th
 
 * FIX: `force:source:pull` respects `.forceignore` entries in the format `**.filename.ext`. Thank you @ImJohnMDaniel for [reporting this](https://github.com/forcedotcom/cli/issues/1471) with an excellent repro!
 * FIX: `force:source:push` will correctly push LWC subfolders such as `force-app/lwc/foo/lwc/myLWC/**`. Thank you @yippie for [reporting](https://github.com/forcedotcom/cli/issues/1477) :bow:.
+* FIX: Deploys that time out now [include the deploy ID](https://github.com/forcedotcom/source-deploy-retrieve/pull/614), making various automations possible that otherwise required workarounds.
 
 ## 7.148.3 (April 29, 2022) [stable]
 

--- a/releasenotes/sfdx/README.md
+++ b/releasenotes/sfdx/README.md
@@ -14,9 +14,11 @@ If you use [autocomplete](https://developer.salesforce.com/docs/atlas.en-us.sfdx
 
 Want to check out the new `sf` executable of Salesforce CLI? [Click here for the release notes.](../sf/README.md)
 
-## 7.148.0 (April 29, 2022) [stable-rc]
+## 7.149.0 (May 5, 2022) [stable-rc]
 
 These changes are in the Salesforce CLI release candidate. We plan to include these changes in next week's official release. This list isn't final and is subject to change.
+
+## 7.148.3 (April 29, 2022) [stable]
 
 > Note: we normally release on Thursdays, so you'd expect this to say April 28.  But since that's also day 2 of TDX, so we'll do the normal release stuff on Friday this week.
 

--- a/releasenotes/sfdx/README.md
+++ b/releasenotes/sfdx/README.md
@@ -18,6 +18,8 @@ Want to check out the new `sf` executable of Salesforce CLI? [Click here for the
 
 These changes are in the Salesforce CLI release candidate. We plan to include these changes in next week's official release. This list isn't final and is subject to change.
 
+* FIX: `force:source:pull` now respects `.forceignore` entries in the format `**.filename.ext`. Thank you @ImJohnMDaniel for [reporting this](https://github.com/forcedotcom/cli/issues/1471) with an excellent repro!
+
 ## 7.148.3 (April 29, 2022) [stable]
 
 > Note: we normally release on Thursdays, so you'd expect this to say April 28.  But since that's also day 2 of TDX, so we'll do the normal release stuff on Friday this week.

--- a/releasenotes/sfdx/README.md
+++ b/releasenotes/sfdx/README.md
@@ -16,9 +16,12 @@ Want to check out the new `sf` executable of Salesforce CLI? [Click here for the
 
 ## 7.149.0 (May 5, 2022) [stable-rc]
 
+* HEADS-UP: In next week's 7.150 RC, we plan to make the new open-source `mdapi:beta` commands (`convert`, `deploy`, `retrieve`, `deploy:report`, `retrieve:report`) the default, and move the old versions of those commands to the legacy subtopic.  Other than some new features (ex: retrieve AND automatically unzip) you shouldn't see breaking changes, but if that's not the case, you can still use the `legacy` versions of them.  You can try them now via the `beta` subtopic to test them out early and report anything that's not right. 
+  
 These changes are in the Salesforce CLI release candidate. We plan to include these changes in next week's official release. This list isn't final and is subject to change.
 
-* FIX: `force:source:pull` respects `.forceignore` entries in the format `**.filename.ext`. Thank you @ImJohnMDaniel for [reporting this](https://github.com/forcedotcom/cli/issues/1471) with an excellent repro!
+* FIX: `force:source:pull` was not ignoring certain files in your `.forceignore` when the files didn't exist locally, so we fixed that.  Thank you @ImJohnMDaniel for [reporting this](https://github.com/forcedotcom/cli/issues/1471) with an excellent repro!
+* FIX: `force:source:pull` won't create duplicate files you have in your default directory but not under main/default.  More credit to @ImJohnMDaniel for [noticing](https://github.com/forcedotcom/cli/issues/1485)
 * FIX: `force:source:push` will correctly push LWC subfolders such as `force-app/lwc/foo/lwc/myLWC/**`. Thank you @yippie for [reporting](https://github.com/forcedotcom/cli/issues/1477) :bow:.
 * FIX: Deploys that time out now [include the deploy ID](https://github.com/forcedotcom/source-deploy-retrieve/pull/614), making various automations possible that otherwise required workarounds.
 


### PR DESCRIPTION
Release notes for April 29. This release is going out 24hrs after our normal schedule to account for TDX.