### PR TITLE
chore: add git2gus support for AFDX issues @W-21566927

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -1,12 +1,13 @@
 {
   "productTag": "a1aB00000004Bx8IAE",
-  "defaultBuild": "offcore.tooling.58",
+  "productTagLabels": { "area:afdx": "a1aEE000001vDZRYA2" },
+  "defaultBuild": "offcore.tooling.66",
   "issueTypeLabels": {
     "feature": "USER STORY",
     "regression": "BUG P1",
     "bug": "BUG P3"
   },
-  "hideWorkItemUrl": false,
+  "hideWorkItemUrl": true,
   "statusWhenClosed": "CLOSED",
   "issueEpicMapping": {
     "BUG P1": "a3QB00000004yR1MAI",


### PR DESCRIPTION
Adds the product tag mapping for Agentforce DX to git2gus
Bumps the default build to 66.0
hideWorkItemUrl should be `true` for public repos
@W-21566927@