### PR TITLE
fix: update to string value in hideWorkItemUrl-W-22248470

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -7,7 +7,7 @@
     "regression": "BUG P1",
     "bug": "BUG P3"
   },
-  "hideWorkItemUrl": true,
+  "hideWorkItemUrl": "true",
   "statusWhenClosed": "CLOSED",
   "issueEpicMapping": {
     "BUG P1": "a3QB00000004yR1MAI",


### PR DESCRIPTION
Fix hideWorkItemUrl value so that labeling a bug correctly creates a GUS work item.  

@W-22248470@