### PR TITLE
sf RNs: May 20, 2026 - agent preview/publish JWT fix

### DIFF
--- a/releasenotes/README.md
+++ b/releasenotes/README.md
@@ -79,6 +79,8 @@ These changes are in the Salesforce CLI release candidate. We plan to include th
 
 * FIX: We are now correctly digitally signing all downloadable Salesforce CLI packages and executables. (GitHub Issue [#3547](https://github.com/forcedotcom/cli/issues/3547))
 
+* FIX: (Agentforce DX) The `agent preview` and `agent publish` commands no longer fail with JWT token errors when calling their associated APIs. The fix isolates JWT connections used for Salesforce AI Platform APIs from standard connections used for org operations, which prevents token clobbering during connection refresh. (plugin-agent PR [#421](https://github.com/salesforcecli/plugin-agent/pull/421), agents PR [#278](https://github.com/forcedotcom/agents/pull/278))
+
 ## 2.134.6 (May 13, 2026) [stable]
 
 * NEW: Successfully run Apex tests in a scratch org that send emails to users with unverified email domains by setting the `EmailAuthorizationSettings.enableSubstituteFromAddress` field to `true` in your scratch org definition file. With this scratch org feature you can work around the [new Salesforce requirement](https://help.salesforce.com/s/articleView?id=005316090&type=1) that emails sent from Salesforce must have verified email domains.  Here's an example of including this setting in a scratch org definition file.

--- a/releasenotes/README.md
+++ b/releasenotes/README.md
@@ -79,7 +79,7 @@ These changes are in the Salesforce CLI release candidate. We plan to include th
 
 * FIX: We are now correctly digitally signing all downloadable Salesforce CLI packages and executables. (GitHub Issue [#3547](https://github.com/forcedotcom/cli/issues/3547))
 
-* FIX: (Agentforce DX) The `agent preview` and `agent publish` commands no longer fail with JWT token errors when calling their associated APIs. The fix isolates JWT connections used for Salesforce AI Platform APIs from standard connections used for org operations, which prevents token clobbering during connection refresh. (plugin-agent PR [#421](https://github.com/salesforcecli/plugin-agent/pull/421), agents PR [#278](https://github.com/forcedotcom/agents/pull/278))
+* FIX: (Agentforce DX) The `agent preview` and `agent publish` commands no longer fail with HTTP 404 errors when user permissions are correct. The fix isolates connections used when calling server APIs, preventing token clobbering during connection refreshes. (plugin-agent PR [#421](https://github.com/salesforcecli/plugin-agent/pull/421), agents PR [#278](https://github.com/forcedotcom/agents/pull/278))
 
 ## 2.134.6 (May 13, 2026) [stable]
 

--- a/releasenotes/README.md
+++ b/releasenotes/README.md
@@ -79,7 +79,7 @@ These changes are in the Salesforce CLI release candidate. We plan to include th
 
 * FIX: We are now correctly digitally signing all downloadable Salesforce CLI packages and executables. (GitHub Issue [#3547](https://github.com/forcedotcom/cli/issues/3547))
 
-* FIX: (Agentforce DX) The `agent preview` and `agent publish` commands no longer fail with HTTP 404 errors when user permissions are correct. The fix isolates connections used when calling server APIs, preventing token clobbering during connection refreshes. (plugin-agent PR [#421](https://github.com/salesforcecli/plugin-agent/pull/421), agents PR [#278](https://github.com/forcedotcom/agents/pull/278))
+* FIX: (Agentforce DX) The `agent preview` and `agent publish authoring-bundle` commands no longer fail with HTTP 404 errors when user permissions are correct. The fix isolates connections used when calling server APIs, preventing token clobbering during connection refreshes. (plugin-agent PR [#421](https://github.com/salesforcecli/plugin-agent/pull/421), agents PR [#278](https://github.com/forcedotcom/agents/pull/278))
 
 ## 2.134.6 (May 13, 2026) [stable]
 


### PR DESCRIPTION
## Summary
- Adds a FIX entry to the 2.135.7 [stable-rc] release notes for the agent preview/publish JWT token errors, fixed by [agents PR #278](https://github.com/forcedotcom/agents/pull/278) and consumed by [plugin-agent PR #421](https://github.com/salesforcecli/plugin-agent/pull/421).

## Test plan
- [ ] Verify rendered Markdown in `releasenotes/README.md` under the 2.135.7 section.
- [ ] Confirm linked PRs resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)