### PR TITLE
W-23145690 sf RNs: June 24, 2026

### DIFF
--- a/releasenotes/README.md
+++ b/releasenotes/README.md
@@ -25,15 +25,21 @@ Additional documentation:
 * [Salesforce CLI Plugin Developer Guide](https://github.com/salesforcecli/cli/wiki/Quick-Introduction-to-Developing-sf-Plugins)
 * [Salesforce CLI Setup Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_intro.htm)
 
-## 2.140.6 (June 24, 2026) [stable-rc]
+## 2.141.6 (July 1, 2026) [stable-rc]
 
 These changes are in the Salesforce CLI release candidate. We plan to include these changes in next week's official release. This list isn't final and is subject to change.
 
 ------------
 
+* FIX: [String replacement](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_ws_string_replace.htm) on big metadata files now works correctly. (GitHub Issue [#3461](https://github.com/forcedotcom/cli/issues/3461), source-deploy-retrieve PR [#1699](https://github.com/forcedotcom/source-deploy-retrieve/pull/1699))
+
+    Big shoutout to [Bartheleway](https://github.com/Bartheleway) who dove into the Salesforce CLI code and fixed this issue. Our team and community thank you! 
+
+## 2.140.6 (June 24, 2026) [stable]
+
 * FIX: We fixed some under-the-hood bugs.
 
-## 2.139.6 (June 17, 2026) [stable]
+## 2.139.6 (June 17, 2026)
 
 * FIX: Salesforce DX projects now support the HouseholdNamingConfig [metadata type](https://github.com/forcedotcom/source-deploy-retrieve/blob/main/src/registry/metadataRegistry.json).
 


### PR DESCRIPTION
Updated release notes for version 2.141.6, including a fix for string replacement on big metadata files and acknowledgment for contributor Bartheleway.